### PR TITLE
Handle HTML responses from the schema registry server

### DIFF
--- a/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
+++ b/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
@@ -29,7 +29,7 @@ import scala.util.control.NonFatal
 class JerseySchemaRegistryClient(settings: SchemaRegistryClientSettings)
     extends SchemaRegistryClient
     with AutoCloseable {
-  
+
   private val logger = LoggerFactory.getLogger(getClass)
 
   // This cache the schema id by subject and schema
@@ -155,7 +155,7 @@ class JerseySchemaRegistryClient(settings: SchemaRegistryClientSettings)
   override def close(): Unit =
     client.close()
 
-  private def processResponse[T](r: Response)(f: Response => T) = {
+  private def processResponse[T](r: Response)(f: Response => T) =
     try {
       if (r.getStatus == 200) {
         f(r)
@@ -165,7 +165,6 @@ class JerseySchemaRegistryClient(settings: SchemaRegistryClientSettings)
     } finally {
       r.close()
     }
-  }
 
   private def parseRestException(response: Response) = {
     response.bufferEntity() // so we can read it more than once
@@ -173,10 +172,16 @@ class JerseySchemaRegistryClient(settings: SchemaRegistryClientSettings)
       val jsonObject = response.readEntity(classOf[JsonObject])
       new RestClientException(jsonObject.getString("message"), response.getStatus, jsonObject.getInt("error_code"))
     } catch {
-      case NonFatal(_) => 
+      case NonFatal(_) =>
         val truncatedResponseBody = response.readEntity(classOf[String]).take(10000).mkString
-        logger.warn("Schema registry returned a non-JSON.response. Status: ${response.getStatus}. Response (truncated): $truncatedResponseBody")
-        new RestClientException("Server returned a non-JSON response. See the logs for details.", response.getStatus, -1)
+        logger.warn(
+          "Schema registry returned a non-JSON.response. Status: ${response.getStatus}. Response (truncated): $truncatedResponseBody"
+        )
+        new RestClientException(
+          "Server returned a non-JSON response. See the logs for details.",
+          response.getStatus,
+          -1
+        )
     }
   }
 }

--- a/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
+++ b/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
@@ -12,6 +12,7 @@ import io.confluent.kafka.schemaregistry.client.{SchemaMetadata, SchemaRegistryC
 import jersey.repackaged.com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import org.apache.avro.Schema
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature
+import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -28,6 +29,8 @@ import scala.util.control.NonFatal
 class JerseySchemaRegistryClient(settings: SchemaRegistryClientSettings)
     extends SchemaRegistryClient
     with AutoCloseable {
+  
+  private val logger = LoggerFactory.getLogger(getClass)
 
   // This cache the schema id by subject and schema
   private val subjectSchemaCache: LoadingCache[SchemaCacheKey, java.lang.Integer] = CacheBuilder
@@ -152,19 +155,28 @@ class JerseySchemaRegistryClient(settings: SchemaRegistryClientSettings)
   override def close(): Unit =
     client.close()
 
-  private def processResponse[T](r: Response)(f: Response => T) =
-    if (r.getStatus == 200) {
-      f(r)
-    } else {
-      throw parseRestException(r)
+  private def processResponse[T](r: Response)(f: Response => T) = {
+    try {
+      if (r.getStatus == 200) {
+        f(r)
+      } else {
+        throw parseRestException(r)
+      }
+    } finally {
+      r.close()
     }
+  }
 
   private def parseRestException(response: Response) = {
+    response.bufferEntity() // so we can read it more than once
     try {
       val jsonObject = response.readEntity(classOf[JsonObject])
       new RestClientException(jsonObject.getString("message"), response.getStatus, jsonObject.getInt("error_code"))
     } catch {
-      case NonFatal(_) => new RestClientException("Server returned a non-JSON response", response.getStatus, -1)
+      case NonFatal(_) => 
+        val truncatedResponseBody = response.readEntity(classOf[String]).take(10000).mkString
+        logger.warn("Schema registry returned a non-JSON.response. Status: ${response.getStatus}. Response (truncated): $truncatedResponseBody")
+        new RestClientException("Server returned a non-JSON response. See the logs for details.", response.getStatus, -1)
     }
   }
 }

--- a/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
+++ b/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
@@ -15,6 +15,7 @@ import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 
 /**
   * Implements the [[SchemaRegistryClient]] interface using Jersey client.
@@ -159,8 +160,12 @@ class JerseySchemaRegistryClient(settings: SchemaRegistryClientSettings)
     }
 
   private def parseRestException(response: Response) = {
-    val jsonObject = response.readEntity(classOf[JsonObject])
-    new RestClientException(jsonObject.getString("message"), response.getStatus, jsonObject.getInt("error_code"))
+    try {
+      val jsonObject = response.readEntity(classOf[JsonObject])
+      new RestClientException(jsonObject.getString("message"), response.getStatus, jsonObject.getInt("error_code"))
+    } catch {
+      case NonFatal(_) => new RestClientException("Server returned a non-JSON response", response.getStatus, -1)
+    }
   }
 }
 

--- a/avro/src/test/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClientSpec.scala
+++ b/avro/src/test/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClientSpec.scala
@@ -97,6 +97,11 @@ class JerseySchemaRegistryClientSpec extends UnitSpec with WireMockFixture with 
         a[RestClientException] should be thrownBy client.register("test-subject", schema)
       }
 
+      "throw an exception in case of a non-JSON response" in withJerseySchemaRegistryClient { client =>
+        givenHtmlResponse(401, "You're unauthorized, sucker!")
+        a[RestClientException] should be thrownBy client.register("test-subject", schema)
+      }
+
       "cache the registered schema" in withJerseySchemaRegistryClient { client =>
         val schemaId = 321
         givenNextSchemaId("test-subject", schemaId)

--- a/avro/src/test/scala/com/ovoenergy/kafka/serialization/avro/SchemaRegistryFixture.scala
+++ b/avro/src/test/scala/com/ovoenergy/kafka/serialization/avro/SchemaRegistryFixture.scala
@@ -97,4 +97,15 @@ trait SchemaRegistryFixture extends BeforeAndAfterEach { _: Suite with WireMockF
         )
     )
 
+  def givenHtmlResponse(status: Int, body: String): Unit =
+    stubFor(
+      any(anyUrl())
+        .willReturn(
+          aResponse()
+            .withStatus(status)
+            .withBody(body)
+            .withHeader("Content-Type", "text/html")
+        )
+    )
+
 }


### PR DESCRIPTION
e.g. in the case of 401 Unauthorized, we get an HTML response