### PR TITLE
Support serialization/deserialization of binary without unnecessary array copying

### DIFF
--- a/avro4s/src/main/scala/com/ovoenergy/kafka/serialization/avro4s/Avro4sSerialization.scala
+++ b/avro4s/src/main/scala/com/ovoenergy/kafka/serialization/avro4s/Avro4sSerialization.scala
@@ -18,23 +18,47 @@ import scala.collection.JavaConverters._
 
 private[avro4s] trait Avro4sSerialization {
 
+  /**
+    * Build a deserializer for binary-encoded messages prepended with a four byte Schema Registry schema ID.
+    *
+    * Assumes that the schema registry does not require authentication.
+    *
+    * @param isKey true if this is a deserializer for keys, false if it is for values
+    * @param includesFormatByte whether the messages are also prepended with a magic byte to specify the Avro format
+    */
   def avroBinarySchemaIdDeserializer[T: FromRecord](schemaRegistryEndpoint: String,
-                                                    isKey: Boolean): KafkaDeserializer[T] =
-    avroBinarySchemaIdDeserializer(SchemaRegistryClientSettings(schemaRegistryEndpoint), isKey)
+                                                    isKey: Boolean,
+                                                    includesFormatByte: Boolean): KafkaDeserializer[T] =
+    avroBinarySchemaIdDeserializer(SchemaRegistryClientSettings(schemaRegistryEndpoint), isKey, includesFormatByte)
 
+  /**
+    * Build a deserializer for binary-encoded messages prepended with a four byte Schema Registry schema ID.
+    *
+    * @param isKey true if this is a deserializer for keys, false if it is for values
+    * @param includesFormatByte whether the messages are also prepended with a magic byte to specify the Avro format
+    */
   def avroBinarySchemaIdDeserializer[T: FromRecord](schemaRegistryClientSettings: SchemaRegistryClientSettings,
-                                                    isKey: Boolean): KafkaDeserializer[T] = {
+                                                    isKey: Boolean,
+                                                    includesFormatByte: Boolean): KafkaDeserializer[T] = {
     val schemaRegistryClient = JerseySchemaRegistryClient(schemaRegistryClientSettings)
-    avroBinarySchemaIdDeserializer(schemaRegistryClient, isKey, () => schemaRegistryClient.close())
+    avroBinarySchemaIdDeserializer(schemaRegistryClient, isKey, () => schemaRegistryClient.close(), includesFormatByte)
   }
 
+  /**
+    * Build a deserializer for binary-encoded messages prepended with a four byte Schema Registry schema ID.
+    *
+    * @param isKey true if this is a deserializer for keys, false if it is for values
+    * @param includesFormatByte whether the messages are also prepended with a magic byte to specify the Avro format
+    */
   def avroBinarySchemaIdDeserializer[T: FromRecord](schemaRegistryClient: SchemaRegistryClient,
-                                                    isKey: Boolean): KafkaDeserializer[T] =
-    avroBinarySchemaIdDeserializer(schemaRegistryClient, isKey, () => Unit)
+                                                    isKey: Boolean,
+                                                    includesFormatByte: Boolean): KafkaDeserializer[T] =
+    avroBinarySchemaIdDeserializer(schemaRegistryClient, isKey, () => Unit, includesFormatByte)
 
   private def avroBinarySchemaIdDeserializer[T: FromRecord](schemaRegistryClient: SchemaRegistryClient,
                                                             isKey: Boolean,
-                                                            close: () => Unit): KafkaDeserializer[T] = {
+                                                            close: () => Unit,
+                                                            includesFormatByte: Boolean): KafkaDeserializer[T] = {
 
     val fromRecord = implicitly[FromRecord[T]]
 
@@ -42,33 +66,79 @@ private[avro4s] trait Avro4sSerialization {
     // The configure method needs the `schema.registry.url` even if the schema registry client has been provided
     d.configure(Map("schema.registry.url" -> "").asJava, isKey)
 
-    deserializer({ (topic, data) =>
-      fromRecord(d.deserialize(topic, Array(0: Byte) ++ data).asInstanceOf[GenericRecord])
-    }, close)
+    deserializer(
+      { (topic, data) =>
+        val bytes = {
+          if (includesFormatByte) data
+          else Array(0: Byte) ++ data // prepend the magic byte before delegating to the KafkaAvroDeserializer
+        }
+
+        fromRecord(d.deserialize(topic, bytes).asInstanceOf[GenericRecord])
+      },
+      close
+    )
   }
 
-  def avroBinarySchemaIdWithReaderSchemaDeserializer[T: FromRecord: SchemaFor](schemaRegistryEndpoint: String,
-                                                                               isKey: Boolean): KafkaDeserializer[T] =
-    avroBinarySchemaIdWithReaderSchemaDeserializer(SchemaRegistryClientSettings(schemaRegistryEndpoint), isKey)
+  /**
+    * Build a deserializer for binary-encoded messages prepended with a four byte Schema Registry schema ID,
+    * allowing you to specify a reader schema.
+    *
+    * Assumes that the schema registry does not require authentication.
+    *
+    * @param isKey true if this is a deserializer for keys, false if it is for values
+    * @param includesFormatByte whether the messages are also prepended with a magic byte to specify the Avro format
+    */
+  def avroBinarySchemaIdWithReaderSchemaDeserializer[T: FromRecord: SchemaFor](
+    schemaRegistryEndpoint: String,
+    isKey: Boolean,
+    includesFormatByte: Boolean
+  ): KafkaDeserializer[T] =
+    avroBinarySchemaIdWithReaderSchemaDeserializer(
+      SchemaRegistryClientSettings(schemaRegistryEndpoint),
+      isKey,
+      includesFormatByte
+    )
 
+  /**
+    * Build a deserializer for binary-encoded messages prepended with a four byte Schema Registry schema ID,
+    * allowing you to specify a reader schema.
+    *
+    * @param isKey true if this is a deserializer for keys, false if it is for values
+    * @param includesFormatByte whether the messages are also prepended with a magic byte to specify the Avro format
+    */
   def avroBinarySchemaIdWithReaderSchemaDeserializer[T: FromRecord: SchemaFor](
     schemaRegistryClientSettings: SchemaRegistryClientSettings,
-    isKey: Boolean
+    isKey: Boolean,
+    includesFormatByte: Boolean
   ): KafkaDeserializer[T] = {
     val schemaRegistryClient = JerseySchemaRegistryClient(schemaRegistryClientSettings)
-    avroBinarySchemaIdWithReaderSchemaDeserializer(schemaRegistryClient, isKey, () => schemaRegistryClient.close())
+    avroBinarySchemaIdWithReaderSchemaDeserializer(
+      schemaRegistryClient,
+      isKey,
+      () => schemaRegistryClient.close(),
+      includesFormatByte
+    )
   }
 
+  /**
+    * Build a deserializer for binary-encoded messages prepended with a four byte Schema Registry schema ID,
+    * allowing you to specify a reader schema.
+    *
+    * @param isKey true if this is a deserializer for keys, false if it is for values
+    * @param includesFormatByte whether the messages are also prepended with a magic byte to specify the Avro format
+    */
   def avroBinarySchemaIdWithReaderSchemaDeserializer[T: FromRecord: SchemaFor](
     schemaRegistryClient: SchemaRegistryClient,
-    isKey: Boolean
+    isKey: Boolean,
+    includesFormatByte: Boolean
   ): KafkaDeserializer[T] =
-    avroBinarySchemaIdWithReaderSchemaDeserializer(schemaRegistryClient, isKey, () => Unit)
+    avroBinarySchemaIdWithReaderSchemaDeserializer(schemaRegistryClient, isKey, () => Unit, includesFormatByte)
 
   private def avroBinarySchemaIdWithReaderSchemaDeserializer[T: FromRecord: SchemaFor](
     schemaRegistryClient: SchemaRegistryClient,
     isKey: Boolean,
-    close: () => Unit
+    close: () => Unit,
+    includesFormatByte: Boolean
   ): KafkaDeserializer[T] = {
 
     val fromRecord = implicitly[FromRecord[T]]
@@ -78,9 +148,17 @@ private[avro4s] trait Avro4sSerialization {
     // The configure method needs the `schema.registry.url` even if the schema registry client has been provided
     d.configure(Map("schema.registry.url" -> "").asJava, isKey)
 
-    deserializer({ (topic, data) =>
-      fromRecord(d.deserialize(topic, data, schemaFor()).asInstanceOf[GenericRecord])
-    }, close)
+    deserializer(
+      { (topic, data) =>
+        val bytes = {
+          if (includesFormatByte) data
+          else Array(0: Byte) ++ data // prepend the magic byte before delegating to the KafkaAvroDeserializer
+        }
+
+        fromRecord(d.deserialize(topic, bytes, schemaFor()).asInstanceOf[GenericRecord])
+      },
+      close
+    )
   }
 
   def avroBinarySchemaIdSerializer[T: ToRecord](schemaRegistryEndpoint: String, isKey: Boolean): KafkaSerializer[T] =

--- a/avro4s/src/test/scala/com/ovoenergy/kafka/serialization/avro4s/Avro4sSerializationSpec.scala
+++ b/avro4s/src/test/scala/com/ovoenergy/kafka/serialization/avro4s/Avro4sSerializationSpec.scala
@@ -27,7 +27,7 @@ class Avro4sSerializationSpec extends UnitSpec with WireMockFixture {
       "is value serializer" should {
         "register the schema to the schemaRegistry for value" in forAll { (topic: String, event: Event) =>
           testWithPostSchemaExpected(s"$topic-value") {
-            val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = false)
+            val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = false, includeFormatByte = false)
             serializer.serialize(topic, event)
           }
         }
@@ -37,7 +37,7 @@ class Avro4sSerializationSpec extends UnitSpec with WireMockFixture {
             whenever(events.length > 1) {
               // This verifies that the HTTP cal to the schema registry happen only once.
               testWithPostSchemaExpected(s"$topic-value") {
-                val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = false)
+                val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = false, includeFormatByte = false)
                 events.foreach(event => serializer.serialize(topic, event))
               }
             }
@@ -48,7 +48,7 @@ class Avro4sSerializationSpec extends UnitSpec with WireMockFixture {
       "is key serializer" should {
         "register the schema to the schemaRegistry for key" in forAll { (topic: String, event: Event) =>
           testWithPostSchemaExpected(s"$topic-key") {
-            val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = true)
+            val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = true, includeFormatByte = false)
             serializer.serialize(topic, event)
           }
         }

--- a/doc/src/main/tut/README.md
+++ b/doc/src/main/tut/README.md
@@ -33,15 +33,18 @@ The library is available in the Bintray OVO repository. Add this snippet to your
 import sbt._
 import sbt.Keys.
 
-resolvers += Resolver.bintray("ovotech", "maven)
+resolvers += Resolver.bintrayRepo("ovotech", "maven")
 
-libraryDependencies ++= Seq(
-  "com.ovoenergy" %% "kafka-serialization-core",
-  "com.ovoenergy" %% "kafka-serialization-circe", // To provide Circe JSON support
-  "com.ovoenergy" %% "kafka-serialization-json4s", // To provide Json4s JSON support
-  "com.ovoenergy" %% "kafka-serialization-spray", // To provide Spray-json JSON support
-  "com.ovoenergy" %% "kafka-serialization-avro4s" // To provide Avro4s Avro support
-)
+libraryDependencies ++= {
+  val kafkaSerializationV = "0.1.23" // see the Maven badge above for the latest version
+  Seq(
+    "com.ovoenergy" %% "kafka-serialization-core" % kafkaSerializationV,
+    "com.ovoenergy" %% "kafka-serialization-circe" % kafkaSerializationV, // To provide Circe JSON support
+    "com.ovoenergy" %% "kafka-serialization-json4s" % kafkaSerializationV, // To provide Json4s JSON support
+    "com.ovoenergy" %% "kafka-serialization-spray" % kafkaSerializationV, // To provide Spray-json JSON support
+    "com.ovoenergy" %% "kafka-serialization-avro4s" % kafkaSerializationV // To provide Avro4s Avro support
+  )
+}
 
 ```
 
@@ -129,7 +132,7 @@ implicit val UserCreatedFromRecord = FromRecord[UserCreated]
 val consumer = new KafkaConsumer(
   Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava,
   nullDeserializer[Unit],
-  avroBinarySchemaIdDeserializer[UserCreated](schemaRegistryEndpoint, isKey = false)
+  avroBinarySchemaIdDeserializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = false)
 )
 ```
 
@@ -175,7 +178,7 @@ implicit val UserCreatedSchemaFor = SchemaFor[UserCreated]
 val consumer = new KafkaConsumer(
   Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava,
   nullDeserializer[Unit],
-  avroBinarySchemaIdWithReaderSchemaDeserializer[UserCreated](schemaRegistryEndpoint, isKey = false)
+  avroBinarySchemaIdWithReaderSchemaDeserializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = false)
 )
 ```
 
@@ -227,10 +230,16 @@ val consumer = new KafkaConsumer(
   nullDeserializer[Unit],
   formatDemultiplexerDeserializer[UserCreated](unknownFormat => failingDeserializer(new RuntimeException("Unsupported format"))){
     case Format.Json => circeJsonDeserializer[UserCreated]
-    case Format.AvroBinarySchemaId => avroBinarySchemaIdDeserializer[UserCreated](schemaRegistryEndpoint, isKey = false)
+    case Format.AvroBinarySchemaId => avroBinarySchemaIdDeserializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = false)
   }
 )
 
+/* This consumer will be able to consume messages in Avro binary format with the magic format byte at the start */
+val consumer = new KafkaConsumer(
+  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava,
+  nullDeserializer[Unit],
+  avroBinarySchemaIdDeserializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = true)
+)
 ```
 
 You can notice that the `formatDemultiplexerDeserializer` is little bit nasty because it is invariant in the type `T` so

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 // https://github.com/sbt/sbt-bintray/issues/104
 // addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.4.0")
 
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.5.1")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.5.6")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt-coursier" % "1.7")
 
 // To resolve custom bintray-sbt plugin


### PR DESCRIPTION
Serialization
===

Before
------

```scala
formatSerializer(
  AvroBinarySchemaId,
  avroBinarySchemaIdSerializer[T](schemaRegistryClient, isKey = false))
```

This does the following:

1. The underlying `AvroKafkaSerializer` adds the magic byte
2. `avroBinarySchemaIdSerializer` removes it (one array copy)
3. `formatSerializer` adds it again (another array copy)

After
-----

```scala
avroBinarySchemaIdSerializer[T](schemaRegistryClient, isKey = false,
  includeFormatByte = true)
```

This skips the format byte dance, meaning no array copying.

Deserialization
===

Before
------

```scala
formatCheckingDeserializer(
  AvroBinarySchemaId,
  avroBinarySchemaIdDeserializer[A](schemaRegistryClient, isKey = false))
```

This does the following:

1. `formatCheckingDeserializer` checks the magic byte and then drops it, resulting in an array copy
2. `avroBinarySchemaIdSerializer` puts the magic byte back again, resulting in another array copy

So the entire Kafka message is copied twice.

After
-----

```scala
avroBinarySchemaIdDeserializer[E](schemaRegistryClient, isKey = false,
  includesFormatByte = true)
```

This skips the format byte dance, so there are no array copies.

The format byte is still checked by the underlying KafkaAvroSerializer.

Other stuff
===

* Upgraded tut and added invisible blocks to clean up resources (without this, sbt was using 400% CPU after running tut!)