### PR TITLE
Fix API inconsistencies and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ implicit val UserCreatedToRecord = ToRecord[UserCreated]
 val producer = new KafkaProducer(
   Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava, 
   nullSerializer[Unit], 
-  avroBinarySchemaIdSerializer[UserCreated](schemaRegistryEndpoint, isKey = false, includeFormatByte = true)
+  avroBinarySchemaIdSerializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = true)
 )
 
 // This type class is need by the avroBinarySchemaIdDeserializer
@@ -222,7 +222,7 @@ case class UserCreated(id: String, name: String, email: String) extends Event
 val avroBinaryProducer = new KafkaProducer(
   Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava, 
   nullSerializer[Unit],   
-  formatSerializer(Format.AvroBinarySchemaId, avroBinarySchemaIdSerializer[UserCreated](schemaRegistryEndpoint, isKey = false, includeFormatByte = false))
+  formatSerializer(Format.AvroBinarySchemaId, avroBinarySchemaIdSerializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = false))
 )
 
 /* This producer will produce messages in Json format */

--- a/avro4s/src/main/scala/com/ovoenergy/kafka/serialization/avro4s/Avro4sSerialization.scala
+++ b/avro4s/src/main/scala/com/ovoenergy/kafka/serialization/avro4s/Avro4sSerialization.scala
@@ -162,50 +162,50 @@ private[avro4s] trait Avro4sSerialization {
   }
 
   /**
-    * Build a deserializer for binary-encoded messages prepended with a four byte Schema Registry schema ID.
+    * Build a serializer for binary-encoded messages prepended with a four byte Schema Registry schema ID.
     *
     * Assumes that the schema registry does not require authentication.
     *
-    * @param isKey true if this is a deserializer for keys, false if it is for values
-    * @param includeFormatByte whether the messages should be prepended with a magic byte to specify the Avro format
+    * @param isKey true if this is a serializer for keys, false if it is for values
+    * @param includesFormatByte whether the messages should be prepended with a magic byte to specify the Avro format
     */
   def avroBinarySchemaIdSerializer[T: ToRecord](schemaRegistryEndpoint: String,
                                                 isKey: Boolean,
-                                                includeFormatByte: Boolean): KafkaSerializer[T] =
-    avroBinarySchemaIdSerializer(SchemaRegistryClientSettings(schemaRegistryEndpoint), isKey, includeFormatByte)
+                                                includesFormatByte: Boolean): KafkaSerializer[T] =
+    avroBinarySchemaIdSerializer(SchemaRegistryClientSettings(schemaRegistryEndpoint), isKey, includesFormatByte)
 
   /**
-    * Build a deserializer for binary-encoded messages prepended with a four byte Schema Registry schema ID.
+    * Build a serializer for binary-encoded messages prepended with a four byte Schema Registry schema ID.
     *
     * Assumes that the schema registry does not require authentication.
     *
-    * @param isKey true if this is a deserializer for keys, false if it is for values
-    * @param includeFormatByte whether the messages should be prepended with a magic byte to specify the Avro format
+    * @param isKey true if this is a serializer for keys, false if it is for values
+    * @param includesFormatByte whether the messages should be prepended with a magic byte to specify the Avro format
     */
   def avroBinarySchemaIdSerializer[T: ToRecord](schemaRegistryClientSettings: SchemaRegistryClientSettings,
                                                 isKey: Boolean,
-                                                includeFormatByte: Boolean): KafkaSerializer[T] = {
+                                                includesFormatByte: Boolean): KafkaSerializer[T] = {
     val schemaRegistryClient = JerseySchemaRegistryClient(schemaRegistryClientSettings)
-    avroBinarySchemaIdSerializer(schemaRegistryClient, isKey, () => schemaRegistryClient.close(), includeFormatByte)
+    avroBinarySchemaIdSerializer(schemaRegistryClient, isKey, () => schemaRegistryClient.close(), includesFormatByte)
   }
 
   /**
-    * Build a deserializer for binary-encoded messages prepended with a four byte Schema Registry schema ID.
+    * Build a serializer for binary-encoded messages prepended with a four byte Schema Registry schema ID.
     *
     * Assumes that the schema registry does not require authentication.
     *
-    * @param isKey true if this is a deserializer for keys, false if it is for values
-    * @param includeFormatByte whether the messages should be prepended with a magic byte to specify the Avro format
+    * @param isKey true if this is a serializer for keys, false if it is for values
+    * @param includesFormatByte whether the messages should be prepended with a magic byte to specify the Avro format
     */
   def avroBinarySchemaIdSerializer[T: ToRecord](schemaRegistryClient: SchemaRegistryClient,
                                                 isKey: Boolean,
-                                                includeFormatByte: Boolean): KafkaSerializer[T] =
-    avroBinarySchemaIdSerializer(schemaRegistryClient, isKey, () => Unit, includeFormatByte)
+                                                includesFormatByte: Boolean): KafkaSerializer[T] =
+    avroBinarySchemaIdSerializer(schemaRegistryClient, isKey, () => Unit, includesFormatByte)
 
   private def avroBinarySchemaIdSerializer[T: ToRecord](schemaRegistryClient: SchemaRegistryClient,
                                                         isKey: Boolean,
                                                         close: () => Unit,
-                                                        includeFormatByte: Boolean): KafkaSerializer[T] = {
+                                                        includesFormatByte: Boolean): KafkaSerializer[T] = {
 
     val toRecord = implicitly[ToRecord[T]]
     val kafkaAvroSerializer = new KafkaAvroSerializer(schemaRegistryClient)
@@ -221,7 +221,7 @@ private[avro4s] trait Avro4sSerialization {
 
     serializer({ (topic, t) =>
       val bytes = kafkaAvroSerializer.serialize(topic, toRecord(t))
-      if (includeFormatByte)
+      if (includesFormatByte)
         bytes
       else
         dropMagicByte(bytes)

--- a/avro4s/src/test/scala/com/ovoenergy/kafka/serialization/avro4s/Avro4sSerializationSpec.scala
+++ b/avro4s/src/test/scala/com/ovoenergy/kafka/serialization/avro4s/Avro4sSerializationSpec.scala
@@ -27,7 +27,7 @@ class Avro4sSerializationSpec extends UnitSpec with WireMockFixture {
       "is value serializer" should {
         "register the schema to the schemaRegistry for value" in forAll { (topic: String, event: Event) =>
           testWithPostSchemaExpected(s"$topic-value") {
-            val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = false, includeFormatByte = false)
+            val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = false, includesFormatByte = false)
             serializer.serialize(topic, event)
           }
         }
@@ -37,7 +37,7 @@ class Avro4sSerializationSpec extends UnitSpec with WireMockFixture {
             whenever(events.length > 1) {
               // This verifies that the HTTP cal to the schema registry happen only once.
               testWithPostSchemaExpected(s"$topic-value") {
-                val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = false, includeFormatByte = false)
+                val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = false, includesFormatByte = false)
                 events.foreach(event => serializer.serialize(topic, event))
               }
             }
@@ -48,7 +48,7 @@ class Avro4sSerializationSpec extends UnitSpec with WireMockFixture {
       "is key serializer" should {
         "register the schema to the schemaRegistry for key" in forAll { (topic: String, event: Event) =>
           testWithPostSchemaExpected(s"$topic-key") {
-            val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = true, includeFormatByte = false)
+            val serializer = avroBinarySchemaIdSerializer(wireMockEndpoint, isKey = true, includesFormatByte = false)
             serializer.serialize(topic, event)
           }
         }

--- a/doc/src/main/tut/README.md
+++ b/doc/src/main/tut/README.md
@@ -127,7 +127,7 @@ implicit val UserCreatedToRecord = ToRecord[UserCreated]
 val producer = new KafkaProducer(
   Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava, 
   nullSerializer[Unit], 
-  avroBinarySchemaIdSerializer[UserCreated](schemaRegistryEndpoint, isKey = false, includeFormatByte = true)
+  avroBinarySchemaIdSerializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = true)
 )
 
 // This type class is need by the avroBinarySchemaIdDeserializer
@@ -227,7 +227,7 @@ case class UserCreated(id: String, name: String, email: String) extends Event
 val avroBinaryProducer = new KafkaProducer(
   Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava, 
   nullSerializer[Unit],   
-  formatSerializer(Format.AvroBinarySchemaId, avroBinarySchemaIdSerializer[UserCreated](schemaRegistryEndpoint, isKey = false, includeFormatByte = false))
+  formatSerializer(Format.AvroBinarySchemaId, avroBinarySchemaIdSerializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = false))
 )
 
 /* This producer will produce messages in Json format */


### PR DESCRIPTION
Closes #26.

Note that I observed some typos in comments (serializers being referred to as deserializers) and fixed these while I was here.