### PR TITLE
Use latest jsoniter-scala version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,7 +81,7 @@ object Dependencies {
 
   object JsoniterScala {
 
-    private val version = "0.5.0"
+    private val version = "0.6.1"
 
     val macros = "com.github.plokhotnyuk.jsoniter-scala" %% "macros" % version
   }


### PR DESCRIPTION
Since 0.5.0 version support for java.util.UUID and java.time.* classes was added and 5 bugs was fixed: https://github.com/plokhotnyuk/jsoniter-scala/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+created%3A%3E2018-01-19+