### PR TITLE
Use latest jsoniter-scala version

### DIFF
--- a/jsoniter-scala/src/main/scala/com/ovoenergy/kafka/serialization/jsoniter_scala/JsoniterScalaSerialization.scala
+++ b/jsoniter-scala/src/main/scala/com/ovoenergy/kafka/serialization/jsoniter_scala/JsoniterScalaSerialization.scala
@@ -8,14 +8,10 @@ private[jsoniter_scala] trait JsoniterScalaSerialization {
 
   def jsoniterScalaSerializer[T](
     config: WriterConfig = WriterConfig()
-  )(implicit codec: JsonCodec[T]): KafkaSerializer[T] = serializer { (_, data) =>
-    JsonWriter.write[T](codec, data, config)
-  }
+  )(implicit codec: JsonCodec[T]): KafkaSerializer[T] = serializer((_, data) => write[T](data, config))
 
   def jsoniterScalaDeserializer[T](
     config: ReaderConfig = ReaderConfig()
-  )(implicit codec: JsonCodec[T]): KafkaDeserializer[T] = deserializer { (_, data) =>
-    JsonReader.read(codec, data, config)
-  }
+  )(implicit codec: JsonCodec[T]): KafkaDeserializer[T] = deserializer((_, data) => read(data, config))
 
 }

--- a/jsoniter-scala/src/test/scala/com/ovoenergy/kafka/serialization/jsoniter_scala/JsoniterScalaSerializationSpec.scala
+++ b/jsoniter-scala/src/test/scala/com/ovoenergy/kafka/serialization/jsoniter_scala/JsoniterScalaSerializationSpec.scala
@@ -16,20 +16,20 @@ class JsoniterScalaSerializationSpec extends UnitSpec with JsoniterScalaSerializ
 
         val jsonBytes = serializer.serialize("does not matter", event)
 
-        jsonBytes.deep shouldBe JsonWriter.write(eventCodec, event).deep
+        jsonBytes.deep shouldBe write(event).deep
       }
       "write prettified json" in forAll { event: Event =>
         val serializer = jsoniterScalaSerializer[Event](WriterConfig(indentionStep = 2))
 
         val jsonBytes = serializer.serialize("does not matter", event)
 
-        jsonBytes.deep shouldBe JsonWriter.write(eventCodec, event, WriterConfig(indentionStep = 2)).deep
+        jsonBytes.deep shouldBe write(event, WriterConfig(indentionStep = 2)).deep
       }
     }
 
     "deserializing" should {
       "parse the json" in forAll { event: Event =>
-        val jsonBytes = JsonWriter.write(eventCodec, event)
+        val jsonBytes = write(event)
         val deserializer = jsoniterScalaDeserializer[Event]()
 
         val deserialized = deserializer.deserialize("does not matter", jsonBytes)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,7 +81,7 @@ object Dependencies {
 
   object JsoniterScala {
 
-    private val version = "0.6.1"
+    private val version = "0.9.4"
 
     val macros = "com.github.plokhotnyuk.jsoniter-scala" %% "macros" % version
   }


### PR DESCRIPTION
Lot of bug fixes and improvements since 0.6.1 version, including breaking of binary compatibility due refactoring of JsonCodec[A] to a typeclass.

See release notes https://github.com/plokhotnyuk/jsoniter-scala/releases or all changes for details https://github.com/plokhotnyuk/jsoniter-scala/compare/v0.6.1...v0.9.4