### PR TITLE
Code changes to upgrade latest versions of kafka and confluent schema registry. 

### DIFF
--- a/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
+++ b/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
@@ -222,6 +222,17 @@ class JerseySchemaRegistryClient(settings: SchemaRegistryClientSettings)
 
   override def getId(subject: String, schema: Schema): Int =
     throw new UnsupportedOperationException
+
+  override  def deleteSchemaVersion(x$1: java.util.Map[String,String],x$2: String,x$3: String): Integer = throw new UnsupportedOperationException
+
+  override def deleteSchemaVersion(x$1: String,x$2: String): Integer = throw new UnsupportedOperationException
+
+  override def deleteSubject(x$1: java.util.Map[String,String],x$2: String): java.util.List[Integer] = throw new UnsupportedOperationException
+
+  override def deleteSubject(x$1: String): java.util.List[Integer] = throw new UnsupportedOperationException
+  
+  override def getAllVersions(x$1: String): java.util.List[Integer] = throw new UnsupportedOperationException
+
 }
 
 object JerseySchemaRegistryClient {

--- a/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
+++ b/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
@@ -223,15 +223,15 @@ class JerseySchemaRegistryClient(settings: SchemaRegistryClientSettings)
   override def getId(subject: String, schema: Schema): Int =
     throw new UnsupportedOperationException
 
-  override  def deleteSchemaVersion(x$1: java.util.Map[String,String],x$2: String,x$3: String): Integer = throw new UnsupportedOperationException
+  override  def deleteSchemaVersion(requestProperties: util.Map[String,String], subject: String, version: String): Integer = throw new UnsupportedOperationException
 
-  override def deleteSchemaVersion(x$1: String,x$2: String): Integer = throw new UnsupportedOperationException
+  override def deleteSchemaVersion(subject: String, version: String): Integer = throw new UnsupportedOperationException
 
-  override def deleteSubject(x$1: java.util.Map[String,String],x$2: String): java.util.List[Integer] = throw new UnsupportedOperationException
+  override def deleteSubject(requestProperties: util.Map[String,String], subject: String): util.List[Integer] = throw new UnsupportedOperationException
 
-  override def deleteSubject(x$1: String): java.util.List[Integer] = throw new UnsupportedOperationException
+  override def deleteSubject(subject: String): util.List[Integer] = throw new UnsupportedOperationException
   
-  override def getAllVersions(x$1: String): java.util.List[Integer] = throw new UnsupportedOperationException
+  override def getAllVersions(subject: String): util.List[Integer] = throw new UnsupportedOperationException
 
 }
 

--- a/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
+++ b/avro/src/main/scala/com/ovoenergy/kafka/serialization/avro/JerseySchemaRegistryClient.scala
@@ -223,16 +223,22 @@ class JerseySchemaRegistryClient(settings: SchemaRegistryClientSettings)
   override def getId(subject: String, schema: Schema): Int =
     throw new UnsupportedOperationException
 
-  override  def deleteSchemaVersion(requestProperties: util.Map[String,String], subject: String, version: String): Integer = throw new UnsupportedOperationException
+  override def deleteSchemaVersion(requestProperties: util.Map[String, String],
+                                   subject: String,
+                                   version: String): Integer =
+    throw new UnsupportedOperationException
 
-  override def deleteSchemaVersion(subject: String, version: String): Integer = throw new UnsupportedOperationException
+  override def deleteSchemaVersion(subject: String, version: String): Integer =
+    throw new UnsupportedOperationException
 
-  override def deleteSubject(requestProperties: util.Map[String,String], subject: String): util.List[Integer] = throw new UnsupportedOperationException
+  override def deleteSubject(requestProperties: util.Map[String, String], subject: String): util.List[Integer] =
+    throw new UnsupportedOperationException
 
-  override def deleteSubject(subject: String): util.List[Integer] = throw new UnsupportedOperationException
-  
-  override def getAllVersions(subject: String): util.List[Integer] = throw new UnsupportedOperationException
+  override def deleteSubject(subject: String): util.List[Integer] =
+    throw new UnsupportedOperationException
 
+  override def getAllVersions(subject: String): util.List[Integer] =
+    throw new UnsupportedOperationException
 }
 
 object JerseySchemaRegistryClient {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,9 +79,9 @@ object Dependencies {
 
   object kafka {
 
-    private val version = "0.11.0.1"
+    private val version = "1.1.0"
 
-    val avroSerializer = "io.confluent" % "kafka-avro-serializer" % "4.0.0" exclude ("org.slf4j", "slf4j-log4j12")
+    val avroSerializer = "io.confluent" % "kafka-avro-serializer" % "4.1.1" exclude ("org.slf4j", "slf4j-log4j12")
     val client = "org.apache.kafka" % "kafka-clients" % version exclude ("org.slf4j", "slf4j-log4j12")
   }
 


### PR DESCRIPTION
Upgraded to latest kafka major version and latest confluent schema registry to use the code:
https://github.com/confluentinc/schema-registry/pull/680
in the `JerseySchemaRegistryClient.scala`