### PR TITLE
Bump kafka-clients dependency 1.1.0 -> 2.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,7 @@ lazy val core = project
   .settings(
     name := "kafka-serialization-core",
     libraryDependencies ++= Seq(
-      "org.apache.kafka" % "kafka-clients" % "1.1.0" exclude ("org.slf4j", "slf4j-log4j12"),
+      "org.apache.kafka" % "kafka-clients" % "2.1.0" exclude ("org.slf4j", "slf4j-log4j12"),
       "org.slf4j" % "slf4j-api" % slf4jVersion,
     )
   )


### PR DESCRIPTION
As this is a major version change in a dependency, I recommend releasing it as 0.4.0 (and combining it with any other binary-breaking changes we want to make).