### PR TITLE
Switch from Tut to Mdoc for documentation compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea/
 .idea_modules/
 *.iml
+.bsp/
 
 # Ensime
 .ensime

--- a/README.md
+++ b/README.md
@@ -31,16 +31,18 @@ and Avro will take care of the conversion.
 
 ## Getting Started
 
-The library is available in the Bintray OVO repository. Add this snippet to your build.sbt to use it.
+ - The library is available in the Kaluza artifactory repository.
+ - See [here](https://kaluza.jfrog.io/artifactory/maven/com/ovoenergy/kafka-serialization-core_2.12/) for the latest version.
+ - Add this snippet to your build.sbt to use it:
 
 ```sbtshell
 import sbt._
 import sbt.Keys.
 
-resolvers += Resolver.bintrayRepo("ovotech", "maven")
+resolvers += "Artifactory" at "https://kaluza.jfrog.io/artifactory/maven"
 
 libraryDependencies ++= {
-  val kafkaSerializationV = "0.1.23" // see the Maven badge above for the latest version
+  val kafkaSerializationV = "0.5.25"
   Seq(
     "com.ovoenergy" %% "kafka-serialization-core" % kafkaSerializationV,
     "com.ovoenergy" %% "kafka-serialization-circe" % kafkaSerializationV, // To provide Circe JSON support

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI Badge](https://circleci.com/gh/ovotech/kafka-serialization.svg?style=shield)](https://circleci.com/gh/ovotech/kafka-serialization)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a2d814f22d4e4facae0f8a3eb1c841fd)](https://www.codacy.com/app/filippo-deluca/kafka-serialization?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ovotech/kafka-serialization&amp;utm_campaign=Badge_Grade)
-[![Download](https://api.bintray.com/packages/ovotech/maven/kafka-serialization/images/download.svg)](https://bintray.com/ovotech/maven/kafka-serialization/_latestVersion)
+[Download](https://kaluza.jfrog.io/artifactory/maven/com/ovoenergy/kafka-serialization-core_2.12/[RELEASE]/kafka-serialization-core_2.12-[RELEASE].jar)
 
 The aim of this library is to provide the Lego&trade; bricks to build a serializer/deserializer for kafka messages. 
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![CircleCI Badge](https://circleci.com/gh/ovotech/kafka-serialization.svg?style=shield)](https://circleci.com/gh/ovotech/kafka-serialization)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a2d814f22d4e4facae0f8a3eb1c841fd)](https://www.codacy.com/app/filippo-deluca/kafka-serialization?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ovotech/kafka-serialization&amp;utm_campaign=Badge_Grade)
-[![Download](https://api.bintray.com/packages/ovotech/maven/kafka-serialization-core/images/download.svg)](https://bintray.com/ovotech/maven/kafka-serialization-core/_latestVersion) [![Join the chat at https://gitter.im/ovotech/kafka-serialization](https://badges.gitter.im/ovotech/kafka-serialization.svg)](https://gitter.im/ovotech/kafka-serialization?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Download](https://api.bintray.com/packages/ovotech/maven/kafka-serialization/images/download.svg)](https://bintray.com/ovotech/maven/kafka-serialization/_latestVersion)
 
-The aim of this library is to provide the Lego&trade; bricks to build a serializer/deserializer for kafka messages.
+The aim of this library is to provide the Lego&trade; bricks to build a serializer/deserializer for kafka messages. 
 
-The serializers/deserializers built by this library cannot be used in the Kafka configuration through properties, but
+The serializers/deserializers built by this library cannot be used in the Kafka configuration through properties, but 
 need to be passed through the Kafka Producer/Consumer constructors (It is feature IMHO).
 
-For the Avro serialization this library uses Avro4s while for JSON it supports Json4s, Circe and Spray out of the box.
+For the Avro serialization this library uses Avro4s while for JSON it supports Json4s, Circe and Spray out of the box. 
 It is quite easy to add support for other libraries as well.
 
 ## Modules
@@ -55,7 +55,7 @@ libraryDependencies ++= {
 
 ## Circe example
 
-Circe is a JSON library for Scala that provides support for generic programming trough Shapeless. You can find more
+Circe is a JSON library for Scala that provides support for generic programming trough Shapeless. You can find more 
 information on the [Circe website](https://circe.github.io/circe).
 
 Simple serialization/deserialization example with Circe:
@@ -77,8 +77,8 @@ import scala.collection.JavaConverters._
 case class UserCreated(id: String, name: String, age: Int)
 
 val producer = new KafkaProducer(
-  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava,
-  nullSerializer[Unit],
+  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava, 
+  nullSerializer[Unit], 
   circeJsonSerializer[UserCreated]
 )
 
@@ -90,11 +90,9 @@ val consumer = new KafkaConsumer(
 ```
 
 
-
-
 ## Jsoniter Scala example
 
-[Jsoniter Scala](https://github.com/plokhotnyuk/jsoniter-scala). is a library that generates codecs for case classes,
+[Jsoniter Scala](https://github.com/plokhotnyuk/jsoniter-scala). is a library that generates codecs for case classes, 
 standard types and collections to get maximum performance of JSON parsing & serialization.
 
 Here is an example of serialization/deserialization with Jsoniter Scala:
@@ -115,10 +113,10 @@ import scala.collection.JavaConverters._
 
 case class UserCreated(id: String, name: String, age: Int)
 
-implicit val userCreatedCodec: JsonValueCodec[UserCreated] = JsonCodecMaker.make[UserCreated](CodecMakerConfig())
+implicit val userCreatedCodec: JsonValueCodec[UserCreated] = JsonCodecMaker.make[UserCreated](CodecMakerConfig)
 
 val producer = new KafkaProducer(
-  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava,
+  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava, 
   nullSerializer[Unit],
   jsoniterScalaSerializer[UserCreated]()
 )
@@ -131,22 +129,20 @@ val consumer = new KafkaConsumer(
 ```
 
 
-
-
 ## Avro example
 
-Apache Avro is a remote procedure call and data serialization framework developed within Apache's Hadoop project. It uses
+Apache Avro is a remote procedure call and data serialization framework developed within Apache's Hadoop project. It uses 
 JSON for defining data types and protocols, and serializes data in a compact binary format.
 
-Apache Avro provide some support to evolve your messages across multiple version without breaking compatibility with
+Apache Avro provide some support to evolve your messages across multiple version without breaking compatibility with 
 older or newer consumers. It supports several encoding formats but two are the most used in Kafka: Binary and Json.
 
-The encoded data is always validated and parsed using a Schema (defined in JSON) and eventually evolved to the reader
+The encoded data is always validated and parsed using a Schema (defined in JSON) and eventually evolved to the reader 
 Schema version.
 
 This library provided the support to Avro by using the [Avro4s](https://github.com/sksamuel/avro4s) libray. It uses macro
 and shapeless to allowing effortless serialization and deserialization. In addition to Avro4s it need a Confluent schema
-registry in place, It will provide a way to control the format of the messages produced in kafka. You can find more
+registry in place, It will provide a way to control the format of the messages produced in kafka. You can find more 
 information in the [Confluent Schema Registry Documentation ](http://docs.confluent.io/current/schema-registry/docs/).
 
 
@@ -171,8 +167,8 @@ case class UserCreated(id: String, name: String, age: Int)
 implicit val UserCreatedToRecord = ToRecord[UserCreated]
 
 val producer = new KafkaProducer(
-  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava,
-  nullSerializer[Unit],
+  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava, 
+  nullSerializer[Unit], 
   avroBinarySchemaIdSerializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = true)
 )
 
@@ -187,15 +183,13 @@ val consumer = new KafkaConsumer(
 ```
 
 
-
-
-This Avro serializer will try to register the schema every new message type it will serialize and will save the obtained
+This Avro serializer will try to register the schema every new message type it will serialize and will save the obtained 
 schema id in cache. The deserializer will contact the schema registry each time it will encounter a message with a never
-seen before schema id.
+seen before schema id. 
 
-The schema id will encoded in the first 4 bytes of the payload. The deserializer will extract the schema id from the
-payload and fetch the schema from the schema registry. The deserializer is able to evolve the original message to the
-consumer schema. The use case is when the consumer is only interested in a part of the original message (schema projection)
+The schema id will encoded in the first 4 bytes of the payload. The deserializer will extract the schema id from the 
+payload and fetch the schema from the schema registry. The deserializer is able to evolve the original message to the 
+consumer schema. The use case is when the consumer is only interested in a part of the original message (schema projection) 
 or when the original message is in a older or newer format of the cosumer schema (schema evolution).
 
 An example of the consumer schema:
@@ -213,7 +207,7 @@ import scala.collection.JavaConverters._
 
 val schemaRegistryEndpoint = "http://localhost:8081"
 
-/* Assuming the original message has been serialized using the
+/* Assuming the original message has been serialized using the 
  * previously defined UserCreated class. We are going to project
  * it ignoring the value of the age
  */
@@ -223,7 +217,7 @@ case class UserCreated(id: String, name: String)
 implicit val UserCreatedFromRecord = FromRecord[UserCreated]
 
 
-/* This type class is need by the avroBinarySchemaIdDeserializer
+/* This type class is need by the avroBinarySchemaIdDeserializer 
  * to obtain the consumer schema
  */
 implicit val UserCreatedSchemaFor = SchemaFor[UserCreated]
@@ -236,14 +230,12 @@ val consumer = new KafkaConsumer(
 ```
 
 
-
-
 ## Format byte
 
-The Original Confluent Avro serializer/deserializer prefix the payload with a "magic" byte to identify that the message
-has been written with the Avro serializer.
+The Original Confluent Avro serializer/deserializer prefix the payload with a "magic" byte to identify that the message 
+has been written with the Avro serializer. 
 
-Similarly this library support the same mechanism by mean of a couple of function. It is even able to multiplex and
+Similarly this library support the same mechanism by mean of a couple of function. It is even able to multiplex and 
 demultiplex different serializers/deserializers based on that format byte. At the moment the supported formats are
   - JSON
   - Avro Binary with schema ID
@@ -262,22 +254,25 @@ import io.circe.syntax._
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.CommonClientConfigs._
+import scala.collection.JavaConverters._
 
 
 sealed trait Event
 case class UserCreated(id: String, name: String, email: String) extends Event
 
+val schemaRegistryEndpoint = "http://localhost:8081"
+
 /* This producer will produce messages in Avro binary format */
 val avroBinaryProducer = new KafkaProducer(
-  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava,
-  nullSerializer[Unit],
+  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava, 
+  nullSerializer[Unit],   
   formatSerializer(Format.AvroBinarySchemaId, avroBinarySchemaIdSerializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = false))
 )
 
 /* This producer will produce messages in Json format */
 val circeProducer = new KafkaProducer(
-  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava,
-  nullSerializer[Unit],
+  Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava, 
+  nullSerializer[Unit],   
   formatSerializer(Format.Json, circeJsonSerializer[UserCreated])
 )
 
@@ -298,8 +293,6 @@ val avroBinaryConsumer = new KafkaConsumer(
   avroBinarySchemaIdDeserializer[UserCreated](schemaRegistryEndpoint, isKey = false, includesFormatByte = true)
 )
 ```
-
-
 
 
 You can notice that the `formatDemultiplexerDeserializer` is little bit nasty because it is invariant in the type `T` so
@@ -332,7 +325,7 @@ val userCreatedDeserializer: Deserializer[Option[UserCreated]] = optionalDeseria
 
 ## Cats instances
 
-The `cats` module provides the `Functor` typeclass instance for the `Deserializer` and `Contravariant` instance for the
+The `cats` module provides the `Functor` typeclass instance for the `Deserializer` and `Contravariant` instance for the 
 `Serializer`. This allow to do:
 
 ```scala
@@ -343,7 +336,7 @@ import org.apache.kafka.common.serialization.{Serializer, Deserializer, IntegerS
 
 val intDeserializer: Deserializer[Int] = (new IntegerDeserializer).asInstanceOf[Deserializer[Int]]
 val stringDeserializer: Deserializer[String] = intDeserializer.map(_.toString)
-
+ 
 val intSerializer: Serializer[Int] = (new IntegerSerializer).asInstanceOf[Serializer[Int]]
 val stringSerializer: Serializer[String] = intSerializer.contramap(_.toInt)
 ```
@@ -356,10 +349,10 @@ Issues and PR's are welcome as well.
 
 ## About this README
 
-The code samples in this README file are checked using [tut](https://github.com/tpolecat/tut).
+The code samples in this README file are checked using [mdoc](https://github.com/scalameta/mdoc).
 
-This means that the `README.md` file is generated from `doc/src/main/tut/README.md`. If you want to make any changes to the README, you should:
+This means that the `README.md` file is generated from `docs/src/README.md`. If you want to make any changes to the README, you should:
 
-1. Edit `doc/src/main/tut/README.md`
-2. Run `sbt tut` to regenerate `./README.md`
+1. Edit `docs/src/README.md`
+2. Run `sbt mdoc` to regenerate `./README.md`
 3. Commit both files to git

--- a/build.sbt
+++ b/build.sbt
@@ -82,16 +82,7 @@ lazy val `kafka-serialization` = project
 lazy val doc = project
   .in(file("doc"))
   .enablePlugins(MdocPlugin)
-  .dependsOn(
-    avro,
-    avro4s,
-    cats,
-    circe,
-    core,
-    json4s,
-    `jsoniter-scala`,
-    spray
-  )
+  .dependsOn(avro, avro4s, cats, circe, core, json4s, `jsoniter-scala`, spray)
   .settings(
     name := "kafka-serialization-doc",
     publishArtifact := false,

--- a/build.sbt
+++ b/build.sbt
@@ -67,11 +67,11 @@ lazy val `kafka-serialization` = project
             url("https://github.com/filosganga")
           )
         ),
-        scalaVersion := "2.12.8",
+        scalaVersion := "2.12.14",
         resolvers ++= Seq(
           Resolver.mavenLocal,
           Resolver.typesafeRepo("releases"),
-          "confluent-release" at "http://packages.confluent.io/maven/"
+          "confluent-release" at "https://packages.confluent.io/maven/"
         )
       )
     )
@@ -81,23 +81,29 @@ lazy val `kafka-serialization` = project
 
 lazy val doc = project
   .in(file("doc"))
-  .enablePlugins(TutPlugin)
+  .enablePlugins(MdocPlugin)
   .dependsOn(
-    avro % Tut,
-    avro4s % Tut,
-    cats % Tut,
-    circe % Tut,
-    core % Tut,
-    json4s % Tut,
-    `jsoniter-scala` % Tut,
-    spray % Tut
+    avro,
+    avro4s,
+    cats,
+    circe,
+    core,
+    json4s,
+    `jsoniter-scala`,
+    spray
   )
   .settings(
     name := "kafka-serialization-doc",
     publishArtifact := false,
     publish := {},
-    tutTargetDirectory := (baseDirectory.value).getParentFile,
-    libraryDependencies ++= Seq("io.circe" %% "circe-generic" % circeVersion)
+    mdocIn := baseDirectory.value / "src",
+    mdocOut := (baseDirectory.value).getParentFile,
+    libraryDependencies ++= Seq(
+      "io.circe" %% "circe-generic" % circeVersion,
+      "org.apache.kafka" % "kafka-clients" % kafkaClientVersion exclude ("org.slf4j", "slf4j-log4j12"),
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % jsoninterScalaVersion,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % jsoninterScalaVersion % Provided
+    )
   )
   .settings(publishSettings)
 

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val `kafka-serialization` = project
             url("https://github.com/filosganga")
           )
         ),
-        scalaVersion := "2.12.14",
+        scalaVersion := "2.12.8",
         resolvers ++= Seq(
           Resolver.mavenLocal,
           Resolver.typesafeRepo("releases"),

--- a/doc/src/README.md
+++ b/doc/src/README.md
@@ -31,16 +31,18 @@ and Avro will take care of the conversion.
 
 ## Getting Started
 
-The library is available in the Bintray OVO repository. Add this snippet to your build.sbt to use it.
+ - The library is available in the Kaluza artifactory repository.
+ - See [here](https://kaluza.jfrog.io/artifactory/maven/com/ovoenergy/kafka-serialization-core_2.12/) for the latest version.
+ - Add this snippet to your build.sbt to use it:
 
 ```sbtshell
 import sbt._
 import sbt.Keys.
 
-resolvers += Resolver.bintrayRepo("ovotech", "maven")
+resolvers += "Artifactory" at "https://kaluza.jfrog.io/artifactory/maven"
 
 libraryDependencies ++= {
-  val kafkaSerializationV = "0.1.23" // see the Maven badge above for the latest version
+  val kafkaSerializationV = "0.5.25"
   Seq(
     "com.ovoenergy" %% "kafka-serialization-core" % kafkaSerializationV,
     "com.ovoenergy" %% "kafka-serialization-circe" % kafkaSerializationV, // To provide Circe JSON support

--- a/doc/src/README.md
+++ b/doc/src/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI Badge](https://circleci.com/gh/ovotech/kafka-serialization.svg?style=shield)](https://circleci.com/gh/ovotech/kafka-serialization)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a2d814f22d4e4facae0f8a3eb1c841fd)](https://www.codacy.com/app/filippo-deluca/kafka-serialization?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ovotech/kafka-serialization&amp;utm_campaign=Badge_Grade)
-[![Download](https://api.bintray.com/packages/ovotech/maven/kafka-serialization/images/download.svg)](https://bintray.com/ovotech/maven/kafka-serialization/_latestVersion)
+[Download](https://kaluza.jfrog.io/artifactory/maven/com/ovoenergy/kafka-serialization-core_2.12/[RELEASE]/kafka-serialization-core_2.12-[RELEASE].jar)
 
 The aim of this library is to provide the Lego&trade; bricks to build a serializer/deserializer for kafka messages. 
 

--- a/doc/src/README.md
+++ b/doc/src/README.md
@@ -60,7 +60,7 @@ information on the [Circe website](https://circe.github.io/circe).
 
 Simple serialization/deserialization example with Circe:
 
-```tut:silent
+```scala mdoc:silent
 import com.ovoenergy.kafka.serialization.core._
 import com.ovoenergy.kafka.serialization.circe._
 
@@ -89,7 +89,7 @@ val consumer = new KafkaConsumer(
 )
 ```
 
-```tut:invisible
+```scala mdoc:invisible
 producer.close()
 consumer.close()
 ```
@@ -101,7 +101,7 @@ standard types and collections to get maximum performance of JSON parsing & seri
 
 Here is an example of serialization/deserialization with Jsoniter Scala:
 
-```tut:silent
+```scala mdoc:silent:reset
 import com.ovoenergy.kafka.serialization.core._
 import com.ovoenergy.kafka.serialization.jsoniter_scala._
 
@@ -117,7 +117,7 @@ import scala.collection.JavaConverters._
 
 case class UserCreated(id: String, name: String, age: Int)
 
-implicit val userCreatedCodec: JsonValueCodec[UserCreated] = JsonCodecMaker.make[UserCreated](CodecMakerConfig())
+implicit val userCreatedCodec: JsonValueCodec[UserCreated] = JsonCodecMaker.make[UserCreated](CodecMakerConfig)
 
 val producer = new KafkaProducer(
   Map[String, AnyRef](BOOTSTRAP_SERVERS_CONFIG->"localhost:9092").asJava, 
@@ -132,7 +132,7 @@ val consumer = new KafkaConsumer(
 )
 ```
 
-```tut:invisible
+```scala mdoc:invisible
 producer.close()
 consumer.close()
 ```
@@ -155,7 +155,7 @@ information in the [Confluent Schema Registry Documentation ](http://docs.conflu
 
 
 An example with Avro4s binary and Schema Registry:
-```tut:silent
+```scala mdoc:silent:reset
 import com.ovoenergy.kafka.serialization.core._
 import com.ovoenergy.kafka.serialization.avro4s._
 
@@ -190,7 +190,7 @@ val consumer = new KafkaConsumer(
 )
 ```
 
-```tut:invisible
+```scala mdoc:invisible
 producer.close()
 consumer.close()
 ```
@@ -205,7 +205,7 @@ consumer schema. The use case is when the consumer is only interested in a part 
 or when the original message is in a older or newer format of the cosumer schema (schema evolution).
 
 An example of the consumer schema:
-```tut:silent
+```scala mdoc:silent:reset
 import com.ovoenergy.kafka.serialization.core._
 import com.ovoenergy.kafka.serialization.avro4s._
 
@@ -241,7 +241,7 @@ val consumer = new KafkaConsumer(
 )
 ```
 
-```tut:invisible
+```scala mdoc:invisible
 consumer.close()
 ```
 
@@ -257,7 +257,7 @@ demultiplex different serializers/deserializers based on that format byte. At th
   - Avro JSON with schema ID
 
 let's see this mechanism in action:
-```tut:silent
+```scala mdoc:silent:reset
 import com.ovoenergy.kafka.serialization.core._
 import com.ovoenergy.kafka.serialization.avro4s._
 import com.ovoenergy.kafka.serialization.circe._
@@ -269,10 +269,13 @@ import io.circe.syntax._
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.CommonClientConfigs._
+import scala.collection.JavaConverters._
 
 
 sealed trait Event
 case class UserCreated(id: String, name: String, email: String) extends Event
+
+val schemaRegistryEndpoint = "http://localhost:8081"
 
 /* This producer will produce messages in Avro binary format */
 val avroBinaryProducer = new KafkaProducer(
@@ -306,7 +309,7 @@ val avroBinaryConsumer = new KafkaConsumer(
 )
 ```
 
-```tut:invisible
+```scala mdoc:invisible
 avroBinaryProducer.close()
 circeProducer.close()
 consumer.close()
@@ -326,7 +329,7 @@ In the core module there are pleanty of serializers and deserializers that handl
 
 To handle the case in which the data is null, you need to wrap the deserializer in the `optionalDeserializer`:
 
-```tut:silent
+```scala mdoc:silent:reset
 import com.ovoenergy.kafka.serialization.core._
 import com.ovoenergy.kafka.serialization.circe._
 
@@ -346,7 +349,7 @@ val userCreatedDeserializer: Deserializer[Option[UserCreated]] = optionalDeseria
 The `cats` module provides the `Functor` typeclass instance for the `Deserializer` and `Contravariant` instance for the 
 `Serializer`. This allow to do:
 
-```tut:silent
+```scala mdoc:silent
 import cats.implicits._
 import com.ovoenergy.kafka.serialization.core._
 import com.ovoenergy.kafka.serialization.cats._
@@ -367,10 +370,10 @@ Issues and PR's are welcome as well.
 
 ## About this README
 
-The code samples in this README file are checked using [tut](https://github.com/tpolecat/tut).
+The code samples in this README file are checked using [mdoc](https://github.com/scalameta/mdoc).
 
-This means that the `README.md` file is generated from `doc/src/main/tut/README.md`. If you want to make any changes to the README, you should:
+This means that the `README.md` file is generated from `docs/src/README.md`. If you want to make any changes to the README, you should:
 
-1. Edit `doc/src/main/tut/README.md`
-2. Run `sbt tut` to regenerate `./README.md`
+1. Edit `docs/src/README.md`
+2. Run `sbt mdoc` to regenerate `./README.md`
 3. Commit both files to git

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.4.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.1
+sbt.version=1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,7 @@
-resolvers += Resolver.bintrayRepo("tpolecat", "maven")
-
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.11")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.21")
 addSbtPlugin("fr.qux" % "sbt-release-tags-only" % "0.5.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 


### PR DESCRIPTION
We are using [Tut](https://github.com/tpolecat/tut) to compile the code blocks in the documentation (I guess to check that the code is valid). This library is unmaintained and the binaries are not available (was bintray) so this is blocking development.

This PR switches over to a different tool for this purpose: [Mdoc](https://scalameta.org/mdoc/docs/tut.html)